### PR TITLE
Windows ImageGrab.grab error handled

### DIFF
--- a/OS_specifics/windows.py
+++ b/OS_specifics/windows.py
@@ -3,6 +3,7 @@ import wmi
 import win32gui
 import win32con
 import win32process
+import time
 
 
 # Connect to WMI
@@ -19,7 +20,14 @@ def set_brightness(brightness):
 
 
 def check_windows():
-    average_brightness = average_light_level()
+    try:
+        average_brightness = average_light_level()
+    except OSError as e:
+        print(f"Error capturing screen: {e}. Retrying in 5 seconds...")
+        time.sleep(5)
+        check_windows()
+        return
+    
     
     if(average_brightness > 100):
         current_brightness = get_brightness()


### PR DESCRIPTION
## Summary
This PR fixes an issue with screen capture on Windows, particularly for secure windows such as UAC prompts or DRM-protected content. 

## Problem
- Standard methods like `ImageGrab.grab` fail to capture secure windows due to restrictions imposed by the Windows operating system.

## Solution
-The script now retries screen capture if secure windows prevent grabbing the screen.


## Testing
- Verified functionality on Windows 10 and Windows 11.
- Tested capturing:
  - Standard windows (e.g., browsers, file explorers).
  - Secure windows (e.g., UAC prompts, system dialogs).
